### PR TITLE
add /usr/share/mime/text/x-sgf.xml

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,9 @@
+## qGo 
+
+qGo is a full featured SGF editor and Go Client (IGS, WING, LGS, CyberORO, Tygem, Tom and eWeiqi) based on Qt4. This repository contains the full SVN tree from Sourceforge.
+
+Go is not the way you think, but an ancient Chinese war game which gets promoted by Japan community. It's called "圍棋(Wei Qi)" in Chinese, "囲碁(Yi Go)" in Japanese, "바둑(Baduk)" in Korean. There're still trillions of people playing Go nowadays, mostly in CJK area and among scientists, physicists, gererals and politicians in US and Europe. Playing Go is a symbol of Upper class.
+
+SGF is the universial format for Go game saves.
+
+This seems to be the only place still developing/porting the Qt3 qGo to Qt4. So welcome to fork/commit.   

--- a/src/src.pro
+++ b/src/src.pro
@@ -196,7 +196,9 @@ linux-* {
     INSTALLS += desktopfile
     filetype.path = /usr/share/mimelnk/text
     filetype.files = sgf.desktop
-    INSTALLS += filetype
+    mimetype.path = /usr/share/mime/text
+    mimetype.files = x-sgf.xml
+    INSTALLS += filetype mimetype
 }
 INCLUDEPATH += network \
 audio \

--- a/src/x-sgf.xml
+++ b/src/x-sgf.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<mime-type xmlns="http://www.freedesktop.org/standards/shared-mime-info" type="text/go-sgf">
+  <!--Created automatically by update-mime-database. DO NOT EDIT!-->
+  <comment>Smart Go Format</comment>
+  <comment xml:lang="ja">賢い囲碁フォーマット</comment>
+  <comment xml:lang="ko"></comment>쑤시는바둑체재</comment>
+  <comment xml:lang="zh_CN">智慧围棋格式</comment>
+  <comment xml:lang="zh_TW">智慧圍棋格式</comment>
+  <acronym>SGF</acronym>
+  <expanded-acronym>Smart Go(Weiqi, Yi Go, Baduk) Format</expanded-acronym>
+  <icon>qgo</icon>
+  <sub-class-of type="text/plain"/>
+  <glob pattern="*.sgf"/>
+</mime-type>


### PR DESCRIPTION
Hi, pzorin,

/usr/share/mimelnk/sgf.destkop is depreciated by freedesktop in Linux.

seems now we use .xml file under /usr/share/mime/.

so I wrote a x-sgf.xml file.
