### PR TITLE
Fix installation on non-Linux and non-Mac Unix OSes

### DIFF
--- a/src/defines.h
+++ b/src/defines.h
@@ -211,15 +211,15 @@ extern class ConnectionWidget * connectionWidget;
 extern QString applicationPath;
 #endif
 
-#ifdef Q_OS_LINUX
-    #define SOUND_PATH_PREFIX			"/usr/share/qgo/sounds/"
-    #define TRANSLATIONS_PATH		"/usr/share/qgo/languages"
+#ifdef Q_OS_WIN
+    #define SOUND_PATH_PREFIX		"sounds/"
+    #define TRANSLATIONS_PATH		"translations/"
 #elif defined(Q_OS_MAC)
 	#define SOUND_PATH_PREFIX			"qGo.app/Contents/Resources/Sounds/"
     #define TRANSLATIONS_PATH		"qGo.app/Contents/Resources/Translations/"
-#else //Q_OS_WIN
-	#define SOUND_PATH_PREFIX			"sounds/"
-    #define TRANSLATIONS_PATH		"translations/"
+#else
+    #define SOUND_PATH_PREFIX		"/usr/share/qgo/sounds/"
+    #define TRANSLATIONS_PATH		"/usr/share/qgo/languages"
 #endif
 
 #endif

--- a/src/src.pro
+++ b/src/src.pro
@@ -164,7 +164,7 @@ SOURCES += displayboard.cpp \
     game_interfaces/qgoboardlocalinterface.cpp \
     newgamedialog.cpp
 
-linux-* {
+unix*:!macx-* {
     QGO_INSTALL_PATH = /usr/share/qgo
     QGO_INSTALL_BIN_PATH = /usr/bin
 


### PR DESCRIPTION
Use the Linux installation paths in any Unix platform different than Mac OS X (still including Linux), so on those OSes qgo is installed correctly.

Because of this, shuffle the defines for sounds and translation paths, so the paths previously used for Linux only are now used for anything different than Windows and Mac OS X.
